### PR TITLE
API lookup item by code instead of ID

### DIFF
--- a/CustomerSite/src/config.ts
+++ b/CustomerSite/src/config.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = "0.4";
+export const APP_VERSION = "0.5-SNAPSHOT";

--- a/api/views.py
+++ b/api/views.py
@@ -14,6 +14,8 @@ class ItemViewSet(viewsets.ModelViewSet):
     authentication_classes = [SessionAuthentication, ]
     queryset = Item.objects.all().order_by('id')
     serializer_class = ItemSerializer
+    lookup_field = 'code'
+
 #TODO: Specific item details
 # receie item code
 


### PR DESCRIPTION
In order for the customer site to function, it needs to be able to retrieve items by their item code instead of ID. This change may break code (though nothing appears to be retrieving items by their ID yet) or there may be a better way to implement it.